### PR TITLE
Other mill to bottom bug with scry; unredundify add_to_card_stack

### DIFF
--- a/Streamable/objects/obj_card/Create_0.gml
+++ b/Streamable/objects/obj_card/Create_0.gml
@@ -47,8 +47,8 @@ var send_to = new RightClickSubMenu("Send To >", my_submenu, spr_envelope);
 var duplicate = new RightClickMenuOption("Duplicate", duplicate_card, noop, noop, spr_copy);
 var note = new RightClickMenuOption("Update Note", update_note,noop,noop, spr_note_sticky);
 var spawn = new RightClickMenuOption("Make Spawner", create_spawner, noop, noop);
-var add_counter = new RightClickMenuOption("Add Counter", function(card_inst) { card_inst.counters++ }, noop, noop, spr_counter_add);
-var rem_counter = new RightClickMenuOption("Remove Counter", function(card_inst) { card_inst.counters = max(0, card_inst.counters - 1) }, noop, noop, spr_counter_rem);
+var add_counter = new RightClickMenuOption("Add Counter", add_card_counters, noop, noop, spr_counter_add);
+var rem_counter = new RightClickMenuOption("Remove Counter", sub_card_counters, noop, noop, spr_counter_rem);
 var destroy = new RightClickMenuOption("Delete", card_destroy, noop, noop, spr_trash);
 destroy.draw_color = c_red;
 

--- a/Streamable/objects/obj_card/KeyPress_1.gml
+++ b/Streamable/objects/obj_card/KeyPress_1.gml
@@ -1,0 +1,18 @@
+/// @description Insert description here
+if not is_hovering and not (is_selected and not is_dragged) return;
+if !keys_are_active() return;
+
+clear_menus(self);
+
+// can't use ord() or vk_* for Equal/Plus or Minus buttons
+#macro vk_EqualPlus 187
+#macro vk_Minus 189
+
+var _key = keyboard_lastkey;
+
+//counters up or down
+if _key == vk_EqualPlus or _key == vk_add {
+	add_card_counters(self)
+} else if _key == vk_Minus or _key == vk_subtract {
+	sub_card_counters(self)
+}

--- a/Streamable/objects/obj_card/KeyPress_107.gml
+++ b/Streamable/objects/obj_card/KeyPress_107.gml
@@ -1,6 +1,0 @@
-/// @description Insert description here
-if not is_hovering and not (is_selected and not is_dragged) return;
-if !keys_are_active() return;
-
-clear_menus();
-counters++;

--- a/Streamable/objects/obj_card/KeyPress_109.gml
+++ b/Streamable/objects/obj_card/KeyPress_109.gml
@@ -1,6 +1,0 @@
-/// @description Insert description here
-if not is_hovering and not (is_selected and not is_dragged) return;
-if !keys_are_active() return;
-
-clear_menus();
-counters = max(0, counters - 1);

--- a/Streamable/objects/obj_card/obj_card.yy
+++ b/Streamable/objects/obj_card/obj_card.yy
@@ -40,11 +40,10 @@
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":88,"eventType":9,"collisionObjectId":null,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":0,"eventType":1,"collisionObjectId":null,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":5,"eventType":6,"collisionObjectId":null,},
-    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":107,"eventType":9,"collisionObjectId":null,},
-    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":109,"eventType":9,"collisionObjectId":null,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":0,"eventType":8,"collisionObjectId":null,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":10,"eventType":7,"collisionObjectId":null,},
     {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":90,"eventType":9,"collisionObjectId":null,},
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":1,"eventType":9,"collisionObjectId":null,},
   ],
   "properties": [
     {"resourceType":"GMObjectProperty","resourceVersion":"1.0","name":"is_hovering","varType":3,"value":"False","rangeEnabled":false,"rangeMin":0.0,"rangeMax":10.0,"listItems":[],"multiselect":false,"filters":[],},

--- a/Streamable/objects/obj_deck/KeyPress_1.gml
+++ b/Streamable/objects/obj_deck/KeyPress_1.gml
@@ -20,8 +20,3 @@ switch (keyboard_lastkey)
 	default:
 	break;
 }
-
-if (keyboard_lastkey == global.keys.draw)
-{
-	
-}	

--- a/Streamable/objects/obj_scry/KeyPress_27.gml
+++ b/Streamable/objects/obj_scry/KeyPress_27.gml
@@ -1,11 +1,11 @@
-/// @description Insert description here
-var final_location = obj_deck;
+/// @description Remaining cards action
+var final_move_fn = move_to_deck_bottom;
 
-if keyboard_check(vk_shift) final_location = obj_graveyard;
-else if keyboard_check(vk_tab) final_location = obj_exile;
+if keyboard_check(vk_shift) final_move_fn = move_to_graveyard
+else if keyboard_check(vk_tab) final_move_fn = move_to_exile
 else array_shuffle(stack_list);
 
 for (var i = array_length(stack_list) - 1; i >= 0; i--)
 {
-	add_to_card_stack(stack_list[i], final_location);
+	final_move_fn(stack_list[i]);
 }

--- a/Streamable/scripts/scr_cards/scr_cards.gml
+++ b/Streamable/scripts/scr_cards/scr_cards.gml
@@ -94,20 +94,7 @@ function move_to_command(card_inst)
 }
 
 function add_to_card_stack(card_inst, stack_inst) {
-	remove_from_card_stack(card_inst);
-	
-	card_inst.parent_stack = stack_inst;
-	card_inst.is_revealed = stack_inst.hidden_zone;
-	array_push(stack_inst.stack_list, card_inst.id);
-	
-	// Untap the card:
-	card_inst.is_tapping = false;
-	card_inst.tapped = false;
-	card_inst.image_angle = 0;
-	layer_add_instance(stack_inst.zone_layer, card_inst);
-	obj_height_manager.height_modified = true;
-	
-	card_inst.is_selected = false;
+	add_to_card_stack_location(card_inst, stack_inst, array_length(stack_inst.stack_list))
 }
 
 function add_to_card_stack_beginning(card_inst, stack_inst) {

--- a/Streamable/scripts/scr_cards/scr_cards.gml
+++ b/Streamable/scripts/scr_cards/scr_cards.gml
@@ -1,5 +1,13 @@
 // Script assets have changed for v2.3.0 see
 // https://help.yoyogames.com/hc/en-us/articles/360005277377 for more information
+function add_card_counters(card_inst, num = 1) {
+	card_inst.counters += num;
+}
+
+function sub_card_counters(card_inst, num = 1) {
+	card_inst.counters = max(0, card_inst.counters - num)
+}
+
 function tap_card(card_inst) 
 {
 	if (!card_inst.is_tapping)
@@ -62,19 +70,16 @@ function create_spawner(card_inst)
 
 function move_to_deck_top(card_inst)
 {
-	card_inst.counters = 0; //this is a private zone and thus it should strip away any counters on the card
 	add_to_card_stack_beginning(card_inst, obj_deck);	
 }
 
 function move_to_deck_bottom(card_inst)
 {
-	card_inst.counters = 0; //this is a private zone and thus it should strip away any counters on the card
 	add_to_card_stack(card_inst, obj_deck);
 }
 
 function move_to_hand(card_inst)
 {
-	card_inst.counters = 0; //this is a private zone and thus it should strip away any counters on the card
 	add_to_card_stack(card_inst, obj_hand);
 }
 
@@ -113,6 +118,9 @@ function add_to_card_stack_location(card_inst, stack_inst, pos)
 	card_inst.is_tapping = false;
 	card_inst.tapped = false;
 	card_inst.image_angle = 0;
+	if stack_inst.hidden_zone {
+		card_inst.counters = 0;
+	}
 	layer_add_instance(stack_inst.zone_layer, card_inst);
 	obj_height_manager.height_modified = true;
 	


### PR DESCRIPTION
- there was was a thing with shift+esc from Scrying also sending to the bottom of the gy instead of top
- refactored add_to_card_stack to just call the one that takes position since 99% of the code was the same
- added minus/underscore button and equal/plus buttons to token +/- (partially because the keybind hints in the other PR can just be "+" and "-" without ambiguity instead of having to say "Numpad' on them)
- i then also refactored some counters stuff to a couple functions and then fixed a bug where dragging a card with counters to a hidden zone wasn't setting them to 0, so now it just checks if the new zone is hidden_zone in the one place all those other functions funnel to... where it was already resetting some card properties.

i have the keybind hints done as well, but i'll wait to see if you merge this so i can handle updating my `main` and then _that_ branch before doing its PR.