### PR TITLE
Bugfix to use numpad as well as number row

### DIFF
--- a/Streamable/objects/obj_keyboard_dispatch/KeyPress_1.gml
+++ b/Streamable/objects/obj_keyboard_dispatch/KeyPress_1.gml
@@ -2,11 +2,13 @@
 if !keys_are_active() return;
 
 // Key is 0-9:
-if keyboard_lastkey >= 48 && keyboard_lastkey <= 57
-{
-	num_repeats *= 10;
-	num_repeats += int64(keyboard_lastkey - 48);
-	return;
+for (var i = 0; i < 10; ++i) {
+	if (keyboard_lastchar == i)
+	{
+		num_repeats *= 10;
+		num_repeats += int64(keyboard_lastchar);
+		return;
+	}
 }
 
 var num_times = max(1,  min(100, num_repeats));


### PR DESCRIPTION
pressing a number on the number row and pressing a command like D to draw, you would draw that number of cards.

This did not work with the numpad.

With this change it works with the numpad. it works by instead of looking at the ID of the key pressed (old: number 0 maps to 48 in number row only), it reads the actual key being pressed (new: number 0 maps to 0 anywhere).

had to do a for loop since setting a range with >= and <= was allowing letters to be passed through which would crash with int64()