### PR TITLE
changelog addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# UNRELEASED
+- Added upside-down flip with shift+F. (No right-click menu entry yet)
+- Fixed bug where only the keyboard top row numbers could be used to preceed `D`, `M`, or `R` keybinds with an amount of cards to draw, mill, or scry (respectively). Now the numpad numbers work, too.
+- Fixed issue where using E (exile), C (command zone), or K (bottom of deck) on a card that was already in the destination zone caused an error and crash.
+
+# 2022.12.17
+- Fixed bugs with loading bad background/sleeve images causing a crash.
+- Added an error window for when loading a background or sleeve image fails.
+- Fixed bugs where cards put into the graveyard with Mill (`M` keybind) or from modifying `Esc` in the Scry view would put them at the bottom instead of the top.
+- Fixed a bug where dragging card(s) to a hidden zone (Deck or Hand) was not clearing the counters.
+- Added keybind hints to right-click menus.
+- Some other misc. bugfixes

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# pisces
+# Pisces
 Pisces Goldfishing Engine for Magic: the Gathering
+
+You can [view the Changelog here](CHANGELOG.md)


### PR DESCRIPTION
just includes the stuff that went into 2022.12.17 -- and what's been merged into `main` since then under UNRELEASED, which would get a version when a new version gets cut as revision 8. the idea is for new sections to go at the top so the latest changes are the most visible. also means we can add to CHANGELOG.md on our work branches as we complete fixes and features, and then the info in the changelog gets merged, too.

i wanted to do this before my next PR because there's quite a few things for me to note, and otherwise it just stays in PR descriptions.